### PR TITLE
Fix media button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
   <title>Tapestry V2.0 Beta</title>
   <script src="./jquery.min.js"></script>
   <script src="./d3.v5.min.js"></script>

--- a/tapestry.css
+++ b/tapestry.css
@@ -85,6 +85,13 @@ text {
     box-shadow: 0 0 0 2px #666 inset;
 }
 
+@supports (-moz-appearance: inherit) {
+    i {
+        background-color: white;
+        padding-bottom: 1.5px;
+    }
+}
+
 .lightbox {
     background-color: rgba(0, 0, 0, 0.8);
     overflow: scroll;

--- a/tapestry.css
+++ b/tapestry.css
@@ -85,11 +85,9 @@ text {
     box-shadow: 0 0 0 2px #666 inset;
 }
 
-@supports (-moz-appearance: inherit) {
-    i {
-        background-color: white;
-        padding-bottom: 1.5px;
-    }
+i {
+    background-color: white;
+    border-radius: 100%;
 }
 
 .lightbox {


### PR DESCRIPTION
The media button should appear with a white background on Chrome, Safari, and FF now. I have not tested on IE or Edge because I don't have anything I can use to test those browsers locally. 

Edit: Edited the code to apply the background to all browsers rather than targeting FF only. 

Fixes #3 